### PR TITLE
refactor: add MultiProvider and remove manual controller passing

### DIFF
--- a/lib/app_widget.dart
+++ b/lib/app_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:pedeai/theme/app_theme.dart';
 
 import 'package:pedeai/model/usuario.dart';
@@ -19,83 +20,70 @@ import 'package:pedeai/view/cadastro/produto/listProdutos.dart';
 import 'package:pedeai/view/cadastro/usuario/cadastroUsuario.dart';
 import 'package:pedeai/view/cadastro/usuario/listUsuario.dart';
 import 'package:pedeai/view/venda/vendaDetalhe.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:pedeai/theme/theme_controller.dart';
 import 'package:pedeai/view/configuracao/configuracao.dart';
 import 'package:pedeai/view/cadastro/fornecedor/listFornecedores.dart';
 import 'package:pedeai/view/cadastro/fornecedor/cadastroFornecedor.dart';
 
-
-class AppWidget extends StatefulWidget {
-  const AppWidget({super.key, required this.themeController});
-  final ThemeController themeController;
-
-  @override
-  State<AppWidget> createState() => _AppWidgetState();
-}
-
-class _AppWidgetState extends State<AppWidget> {
-  late final SupabaseClient supabase;
-
-  @override
-  void initState() {
-    super.initState();
-    // Pega o cliente já inicializado no main.dart
-    supabase = Supabase.instance.client;
-  }
+class AppWidget extends StatelessWidget {
+  const AppWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: widget.themeController, // <- escuta mudanças do tema
-      builder: (_, __) {
-        return MaterialApp(
-          title: 'PedeAi ERP',
-          debugShowCheckedModeBanner: false,
-          theme: buildLightTheme(),
-          darkTheme: buildDarkTheme(),
-          themeMode: widget.themeController.mode, // <- aplica o modo atual
-          initialRoute: '/login',
-          routes: {
-            '/login': (context) => LoginPage(),
-            '/home': (context) => HomePage(),
-            '/listCategorias': (context) => CategoriasPage(),
-            '/listUnidades': (context) => UnidadesPage(),
-            '/listFormasPagamento': (context) => FormasPagamentoPage(),
-            '/listProdutos': (context) => ProductsListPage(),
-            '/cadastro-produto': (context) {
-              final args = ModalRoute.of(context)?.settings.arguments as int?;
-              return CadastroProdutoPage(produtoId: args);
-            },
-            '/listFornecedores': (context) => const ListFornecedoresPage(),
-            '/cadastroFornecedor': (context) {
-                final fornecedorId = ModalRoute.of(context)!.settings.arguments as int?;
-                return CadastroFornecedorPage(fornecedorId: fornecedorId);
-            },
-            '/listUsuarios': (context) => ListUsuarioPage(),
-            '/cadastro-usuario': (context) {
-              final args = ModalRoute.of(context)?.settings.arguments as Usuario?;
-              return CadastroUsuarioPage(usuario: args);
-            },
-            '/estoque': (context) => EstoquePage(),
-            '/pdv': (context) => PDVPage(),
-            '/config': (context) => ThemeSettingsPage(controller: widget.themeController),
-            '/pagamentoPdv': (context) {
-              final args = ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>?;
-              return PagamentoPdvPage(subtotal: args?['subtotal'] ?? 0.0, desconto: args?['desconto'] ?? 0.0, total: args?['total'] ?? 0.0, carrinho: args?['carrinho'] ?? []);
-            },
-
-            '/aberturaCaixa': (context) => AberturaCaixaPage(),
-            '/fechamentoCaixa': (context) => FechamentoCaixaPage(),
-            '/listVendas': (context) => ListagemVendasPage(),
-            '/venda-detalhe': (context) {
-              final args = ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>?;
-              return VendaDetalhePage(idVenda: args?['idVenda'] ?? 0);
-            },
-            '/empresa': (context) => EmpresaPage(),
-          },
-        );
+    final themeController = context.watch<ThemeController>();
+    return MaterialApp(
+      title: 'PedeAi ERP',
+      debugShowCheckedModeBanner: false,
+      theme: buildLightTheme(),
+      darkTheme: buildDarkTheme(),
+      themeMode: themeController.mode,
+      initialRoute: '/login',
+      routes: {
+        '/login': (context) => LoginPage(),
+        '/home': (context) => HomePage(),
+        '/listCategorias': (context) => CategoriasPage(),
+        '/listUnidades': (context) => UnidadesPage(),
+        '/listFormasPagamento': (context) => FormasPagamentoPage(),
+        '/listProdutos': (context) => ProductsListPage(),
+        '/cadastro-produto': (context) {
+          final args = ModalRoute.of(context)?.settings.arguments as int?;
+          return CadastroProdutoPage(produtoId: args);
+        },
+        '/listFornecedores': (context) => const ListFornecedoresPage(),
+        '/cadastroFornecedor': (context) {
+          final fornecedorId =
+              ModalRoute.of(context)!.settings.arguments as int?;
+          return CadastroFornecedorPage(fornecedorId: fornecedorId);
+        },
+        '/listUsuarios': (context) => ListUsuarioPage(),
+        '/cadastro-usuario': (context) {
+          final args = ModalRoute.of(context)?.settings.arguments as Usuario?;
+          return CadastroUsuarioPage(usuario: args);
+        },
+        '/estoque': (context) => EstoquePage(),
+        '/pdv': (context) => PDVPage(),
+        '/config': (context) => const ThemeSettingsPage(),
+        '/pagamentoPdv': (context) {
+          final args =
+              ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>?;
+          return PagamentoPdvPage(
+            subtotal: args?['subtotal'] ?? 0.0,
+            desconto: args?['desconto'] ?? 0.0,
+            total: args?['total'] ?? 0.0,
+            carrinho: args?['carrinho'] ?? [],
+          );
+        },
+        '/aberturaCaixa': (context) => AberturaCaixaPage(),
+        '/fechamentoCaixa': (context) => FechamentoCaixaPage(),
+        '/listVendas': (context) => ListagemVendasPage(),
+        '/venda-detalhe': (context) {
+          final args =
+              ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>?;
+          return VendaDetalhePage(idVenda: args?['idVenda'] ?? 0);
+        },
+        '/empresa': (context) => EmpresaPage(),
       },
     );
   }
 }
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:pedeai/Commom/supabaseConf.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:pedeai/theme/theme_controller.dart';
 import 'package:pedeai/app_widget.dart';
+import 'package:pedeai/theme/theme_controller.dart';
+import 'package:pedeai/controller/caixaController.dart';
+import 'package:pedeai/controller/produtoController.dart';
+import 'package:pedeai/controller/usuarioController.dart';
+import 'package:pedeai/controller/empresaController.dart';
+import 'package:pedeai/controller/categoriaController.dart';
+import 'package:pedeai/controller/unidadeController.dart';
+import 'package:pedeai/controller/formaPagamentoController.dart';
+import 'package:pedeai/controller/fornecedorController.dart';
+import 'package:pedeai/controller/estoqueController.dart';
+import 'package:pedeai/controller/vendaController.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -17,6 +28,25 @@ Future<void> main() async {
   final themeController = ThemeController();
   await themeController.load();
 
-  // Rode o app passando o controller para o AppWidget
-  runApp(AppWidget(themeController: themeController));
+  // Rode o app registrando os controllers via Provider
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<ThemeController>.value(
+          value: themeController,
+        ),
+        Provider(create: (_) => CaixaCotroller()),
+        Provider(create: (_) => Produtocontroller()),
+        Provider(create: (_) => UsuarioController()),
+        Provider(create: (_) => EmpresaController()),
+        Provider(create: (_) => Categoriacontroller()),
+        Provider(create: (_) => Unidadecontroller()),
+        Provider(create: (_) => FormaPagamentocontroller()),
+        Provider(create: (_) => FornecedorController()),
+        Provider(create: (_) => Estoquecontroller()),
+        Provider(create: (_) => VendaController()),
+      ],
+      child: const AppWidget(),
+    ),
+  );
 }

--- a/lib/view/configuracao/configuracao.dart
+++ b/lib/view/configuracao/configuracao.dart
@@ -1,115 +1,111 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:pedeai/theme/app_theme.dart';
 import 'package:pedeai/theme/theme_controller.dart';
 import 'package:pedeai/view/home/drawer.dart';
 import 'package:pedeai/app_nav_bar.dart';
 
 class ThemeSettingsPage extends StatelessWidget {
-  const ThemeSettingsPage({super.key, required this.controller});
-  final ThemeController controller;
+  const ThemeSettingsPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: controller,
-      builder: (_, __) {
-        final cs = Theme.of(context).colorScheme;
-        return Scaffold(
-          appBar: AppBar(
-            leading: Builder(
-              builder: (ctx) => IconButton(
-                icon: Icon(Icons.menu, color: cs.onSurface),
-                onPressed: () => Scaffold.of(ctx).openDrawer(),
-              ),
+    final controller = context.watch<ThemeController>();
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        leading: Builder(
+          builder: (ctx) => IconButton(
+            icon: Icon(Icons.menu, color: cs.onSurface),
+            onPressed: () => Scaffold.of(ctx).openDrawer(),
+          ),
+        ),
+        title: const Text('Configurações'),
+      ),
+      drawer: DrawerPage(
+        currentRoute: ModalRoute.of(context)?.settings.name,
+      ),
+
+      // ⬇️ exatamente como você usa no Produto
+      bottomNavigationBar: AppNavBar(
+        currentRoute: ModalRoute.of(context)?.settings.name,
+      ),
+
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        children: [
+          _SectionTitle('Aparência'),
+          _GroupCard(
+            child: Column(
+              children: [
+                _ThemeRadioTile(
+                  label: 'Seguir o sistema',
+                  value: ThemeMode.system,
+                  group: controller.mode,
+                  onChanged: (m) => controller.setMode(m),
+                ),
+                const Divider(height: 1),
+                _ThemeRadioTile(
+                  label: 'Claro',
+                  value: ThemeMode.light,
+                  group: controller.mode,
+                  onChanged: (m) => controller.setMode(m),
+                  trailing: const _ThemePreview(isDark: false),
+                ),
+                const Divider(height: 1),
+                _ThemeRadioTile(
+                  label: 'Escuro',
+                  value: ThemeMode.dark,
+                  group: controller.mode,
+                  onChanged: (m) => controller.setMode(m),
+                  trailing: const _ThemePreview(isDark: true),
+                ),
+              ],
             ),
-            title: const Text('Configurações'),
           ),
-          drawer: DrawerPage(
-            currentRoute: ModalRoute.of(context)?.settings.name,
-          ),
-
-          // ⬇️ exatamente como você usa no Produto
-          bottomNavigationBar: AppNavBar(
-            currentRoute: ModalRoute.of(context)?.settings.name,
-          ),
-
-          body: ListView(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-            children: [
-              _SectionTitle('Aparência'),
-              _GroupCard(
-                child: Column(
-                  children: [
-                    _ThemeRadioTile(
-                      label: 'Seguir o sistema',
-                      value: ThemeMode.system,
-                      group: controller.mode,
-                      onChanged: (m) => controller.setMode(m),
-                    ),
-                    const Divider(height: 1),
-                    _ThemeRadioTile(
-                      label: 'Claro',
-                      value: ThemeMode.light,
-                      group: controller.mode,
-                      onChanged: (m) => controller.setMode(m),
-                      trailing: const _ThemePreview(isDark: false),
-                    ),
-                    const Divider(height: 1),
-                    _ThemeRadioTile(
-                      label: 'Escuro',
-                      value: ThemeMode.dark,
-                      group: controller.mode,
-                      onChanged: (m) => controller.setMode(m),
-                      trailing: const _ThemePreview(isDark: true),
-                    ),
-                  ],
+          const SizedBox(height: 16),
+          _SectionTitle('Pré-visualização'),
+          const _PreviewCard(),
+          const SizedBox(height: 24),
+          _SectionTitle('Notificações (em breve)'),
+          _GroupCard(
+            child: Column(
+              children: const [
+                _DisabledTile(
+                  icon: Icons.notifications_active_outlined,
+                  title: 'Notificações push',
+                  subtitle: 'Receba alertas de vendas e estoque',
                 ),
-              ),
-              const SizedBox(height: 16),
-              _SectionTitle('Pré-visualização'),
-              const _PreviewCard(),
-              const SizedBox(height: 24),
-              _SectionTitle('Notificações (em breve)'),
-              _GroupCard(
-                child: Column(
-                  children: const [
-                    _DisabledTile(
-                      icon: Icons.notifications_active_outlined,
-                      title: 'Notificações push',
-                      subtitle: 'Receba alertas de vendas e estoque',
-                    ),
-                    Divider(height: 1),
-                    _DisabledTile(
-                      icon: Icons.vibration,
-                      title: 'Feedback tátil',
-                      subtitle: 'Vibração ao executar ações',
-                    ),
-                  ],
+                Divider(height: 1),
+                _DisabledTile(
+                  icon: Icons.vibration,
+                  title: 'Feedback tátil',
+                  subtitle: 'Vibração ao executar ações',
                 ),
-              ),
-              const SizedBox(height: 16),
-              _SectionTitle('PDV (em breve)'),
-              _GroupCard(
-                child: Column(
-                  children: const [
-                    _DisabledTile(
-                      icon: Icons.print_outlined,
-                      title: 'Impressora',
-                      subtitle: 'Modelo, largura de papel e margens',
-                    ),
-                    Divider(height: 1),
-                    _DisabledTile(
-                      icon: Icons.payments_outlined,
-                      title: 'Pagamentos',
-                      subtitle: 'Preferências de formas de pagamento',
-                    ),
-                  ],
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
-        );
-      },
+          const SizedBox(height: 16),
+          _SectionTitle('PDV (em breve)'),
+          _GroupCard(
+            child: Column(
+              children: const [
+                _DisabledTile(
+                  icon: Icons.print_outlined,
+                  title: 'Impressora',
+                  subtitle: 'Modelo, largura de papel e margens',
+                ),
+                Divider(height: 1),
+                _DisabledTile(
+                  icon: Icons.payments_outlined,
+                  title: 'Pagamentos',
+                  subtitle: 'Preferências de formas de pagamento',
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- register ThemeController, CaixaCotroller, Produtocontroller and other controllers with MultiProvider
- simplify AppWidget and ThemeSettingsPage to access controllers via Provider instead of constructor

## Testing
- `dart format lib/main.dart lib/app_widget.dart lib/view/configuracao/configuracao.dart` (fails: command not found)
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c662eaa8832b91df276d91aa0ece